### PR TITLE
Clean up monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+<h1 align="center"><pre><a href="https://weilage.dev">weilage.dev</a></pre></h1>
+
+This is the monorepo for [weilage.dev](https://weilage.dev), a personal website created and developed by me, @jack-weilage.
+
+## Apps
+
+| App             | Description                                           | Built with                                                          |
+| --------------- | ----------------------------------------------------- | ------------------------------------------------------------------- |
+| [cms](apps/cms) | The CMS used for blog posts, to be expanded.          | [sanity.io](https://sanity.io), [React](https://react.dev)          |
+| [web](apps/web) | The main web app. Holds all routing and styling data. | [SvelteKit](https://kit.svelte.dev), [PostCSS](https://postcss.org) |
+
+## Packages
+
+| Package           | Description                                       | Built with                   |
+| ----------------- | ------------------------------------------------- | ---------------------------- |
+| [ui](packages/ui) | The custom UI components used in [web](apps/web). | [Svelte](https://svelte.dev) |

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	"devDependencies": {
 		"lefthook": "^1.4.7",
 		"prettier": "^3.0.0",
-		"prettier-plugin-svelte": "^3.0.1"
+		"prettier-plugin-svelte": "^3.0.3"
 	},
 	"packageManager": "pnpm@8.6.10",
 	"engineStrict": true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -11,8 +15,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       prettier-plugin-svelte:
-        specifier: ^3.0.1
-        version: 3.0.1(prettier@3.0.0)(svelte@4.1.1)
+        specifier: ^3.0.3
+        version: 3.0.3(prettier@3.0.0)(svelte@4.1.1)
 
   apps/cms:
     dependencies:
@@ -944,6 +948,7 @@ packages:
 
   /@emotion/memoize@0.7.4:
     resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
+    requiresBuild: true
     dev: false
     optional: true
 
@@ -3010,6 +3015,7 @@ packages:
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    requiresBuild: true
     dev: false
     optional: true
 
@@ -3026,6 +3032,7 @@ packages:
 
   /fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+    requiresBuild: true
     dev: false
     optional: true
 
@@ -3682,6 +3689,7 @@ packages:
 
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+    requiresBuild: true
     dev: false
     optional: true
 
@@ -4728,8 +4736,8 @@ packages:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
-  /prettier-plugin-svelte@3.0.1(prettier@3.0.0)(svelte@4.1.1):
-    resolution: {integrity: sha512-dSmu5AOQsUFMAj3XrCezQZHp8+6e8bjYu3VKPqY5vVmSU+S/6tXW04es6opnMwRMDH6Vm5r8l4+q8stTI/wuFQ==}
+  /prettier-plugin-svelte@3.0.3(prettier@3.0.0)(svelte@4.1.1):
+    resolution: {integrity: sha512-dLhieh4obJEK1hnZ6koxF+tMUrZbV5YGvRpf2+OADyanjya5j0z1Llo8iGwiHmFWZVG/hLEw/AJD5chXd9r3XA==}
     peerDependencies:
       prettier: ^3.0.0
       svelte: ^3.2.0 || ^4.0.0-next.0
@@ -5774,6 +5782,7 @@ packages:
 
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+    requiresBuild: true
     dependencies:
       punycode: 2.3.0
     dev: false


### PR DESCRIPTION
The original monorepo has way too many packages, making everything so complicated. This PR removes all but one.

Additionally, it removes stylelint and eslint for now, as this project really doesn't need them for now.